### PR TITLE
Allow components to be references

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ export { parseQueryString, generateQueryString } from "./recognizer";
 
 interface RouteDefinition {
   path: string;
-  component: string;
+  component: string | (() => Component<any>);
   data?: (props: { params: Params; query: QueryParams }) => Record<string, unknown>;
   children?: RouteDefinition[];
 }
@@ -156,7 +156,8 @@ function processRoutes(
     const mapped: RouteDef<RouteHandler> = {
       path: root + r.path,
       handler: {
-        component: lazy(() => import(root + r.component)),
+        component:
+          typeof r.component === "string" ? lazy(() => import(root + r.component)) : r.component(),
         data: r.data
       }
     };


### PR DESCRIPTION
this to allow for cases where bundlers or node need explicit references and can't resolve dynamic imports (`import(r.component)`)

e.g. 

```ts
{ path: '/', component: () => HomePage },
{ path: '/about', component: () => import('/about') }
```

this may break the nested routing - open to feedback

