### PR TITLE
Export RouteDefinition

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ import {
 } from "./recognizer";
 export { parseQueryString, generateQueryString } from "./recognizer";
 
-interface RouteDefinition {
+export interface RouteDefinition {
   path: string;
   component: string | Component<any>;
   data?: (props: { params: Params; query: QueryParams }) => Record<string, unknown>;


### PR DESCRIPTION
Exporting RouteDefinition is useful in user land when you are defining your routes in a separate file.

This would allow for something like that:

```ts
import type { RouteDefinition } from 'solid-app-router'

export const routes: RouteDefinition[] = [
  {
    path: '/',
    component: 'pages/home.tsx'
  }
]
```