### PR TITLE
Exposing `data` type with generic

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,25 +10,25 @@ import {
   JSX
 } from "solid-js";
 import { Show, assignProps, isServer } from "solid-js/web";
-import {
-  RecognizeResults,
-  RouteRecognizer,
-  Route as RouteDef,
-  QueryParams,
-  Params
-} from "./recognizer";
+import { RouteRecognizer, Route as RouteDef } from "./recognizer";
+import type { BaseObject, Params, QueryParams, RecognizeResults } from './recognizer';
+
 export { parseQueryString, generateQueryString } from "./recognizer";
+export type { Params } from "./recognizer";
+
+export type DataFnParams<T> = { params: Params<T>; query: QueryParams };
+export type DataFn<T = BaseObject> = (props: DataFnParams<T>) => BaseObject;
 
 export interface RouteDefinition {
   path: string;
   component: Component<any>;
-  data?: (props: { params: Params; query: QueryParams }) => Record<string, unknown>;
+  data?: DataFn;
   children?: RouteDefinition[];
 }
 
 interface RouteHandler {
   component: Component<any>;
-  data?: (props: { params: Params; query: QueryParams }) => Record<string, unknown>;
+  data?: DataFn;
 }
 
 interface Router {

--- a/src/recognizer/index.ts
+++ b/src/recognizer/index.ts
@@ -28,9 +28,9 @@ interface MatchDSL<THandler> {
   (path: string, callback: MatchCallback<THandler>): void;
 }
 
-export interface QueryParams {
-  [param: string]: string[] | string | null | undefined;
-}
+export type QueryParams<T = BaseObject> = 
+  { [K in keyof T]: T[K] }
+  & { [param: string]: string[] | string | null | undefined }
 
 export interface Result<THandler> {
   handler: THandler;

--- a/src/recognizer/index.ts
+++ b/src/recognizer/index.ts
@@ -184,7 +184,7 @@ interface Segment {
 
 export type BaseObject<T = unknown> = Record<string | number, T>;
 
-export type Params<T = Record<string, unknown>> = 
+export type Params<T = BaseObject> = 
   { [K in keyof T]?: T[K] } 
   & { queryParams?: BaseObject | null }
   & BaseObject;

--- a/src/recognizer/index.ts
+++ b/src/recognizer/index.ts
@@ -182,14 +182,12 @@ interface Segment {
   value: string;
 }
 
-export interface Params {
-  [key: string]: unknown;
-  [key: number]: unknown;
-  queryParams?: {
-    [key: string]: unknown;
-    [key: number]: unknown;
-  } | null;
-}
+export type BaseObject<T = unknown> = Record<string | number, T>;
+
+export type Params<T = Record<string, unknown>> = 
+  { [K in keyof T]?: T[K] } 
+  & { queryParams?: BaseObject | null }
+  & BaseObject;
 
 interface ParsedHandler {
   names: string[];


### PR DESCRIPTION
This PR aim to make end user's life easier by allowing them to type the `props.params` object in the `data` function of the `RouteDefinition`. This is done through exposing additional types, illustrated in the following screenshot:

![image](https://user-images.githubusercontent.com/17355226/103142814-887bec80-470a-11eb-8d51-eee0b8467276.png)

You can see on line 3 that you can define a data function through the `DataFn<T>` interface.
You can also see on line 15 that you can also do this inline if you'd rather do that through the `DataFnParams<T>` interface.

In both cases, the `T` generic default to `Record<string | number, unknown>`.

This PR is only partially complete (but should suffice for now) as you can't type the `QueryParams` just yet. The reason being is simple... Typescript doesn't allow for partial inference of generic as far as I know (there's a 2 years old ongoing PR here: [https://github.com/microsoft/TypeScript/pull/26349](https://github.com/microsoft/TypeScript/pull/26349)).
Basically, what that means is, if say we had `DataFn<Params = BaseObject, QueryParams = BaseObject>` and you'd only want to type the first argument of the generic type like so:

```ts
const HomeData: DataFn<{ name: string }> = (props) => ({ ... })
```

Typescript would yell at you saying that the second parameter of the generic is required when this is completely false... I'll go ahead and assume that this is not a big deal as `QueryParams` would be less used at and can be worked around like so:

```ts
const HomeData: DataFn<{ name: string }> = (props) => {
  return {
    get nameFromQuery() {
      const name = props.query.name; // this will have type string | string[];
      return name as string; // we can force it to be a string like this
    }
  }
}
```