### PR TITLE
Adding a way to mark `Link` as external

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,13 +11,17 @@ import {
 } from "solid-js";
 import { Show, assignProps, isServer } from "solid-js/web";
 import { RouteRecognizer, Route as RouteDef } from "./recognizer";
-import type { BaseObject, Params, QueryParams, RecognizeResults } from './recognizer';
+import type { BaseObject, Params, QueryParams, RecognizeResults } from "./recognizer";
 
 export { parseQueryString, generateQueryString } from "./recognizer";
 export type { Params } from "./recognizer";
 
 export type DataFnParams<T> = { params: Params<T>; query: QueryParams };
 export type DataFn<T = BaseObject> = (props: DataFnParams<T>) => BaseObject;
+
+export interface LinkProps extends JSX.AnchorHTMLAttributes<HTMLAnchorElement> {
+  external?: boolean;
+}
 
 export interface RouteDefinition {
   path: string;
@@ -107,13 +111,14 @@ export function Route<T extends { children?: any }>(props: T) {
   );
 }
 
-export const Link: Component<JSX.AnchorHTMLAttributes<HTMLAnchorElement>> = props => {
+export const Link: Component<LinkProps> = props => {
   const router = useRouter(),
-    [p, others] = splitProps(props, ["children"]);
+    [p, others] = splitProps(props, ["children", "external"]);
   return (
     <a
       {...others}
       onClick={e => {
+        if (p.external) return;
         e.preventDefault();
         router.push(props.href || "");
       }}


### PR DESCRIPTION
I took inspiration from [sapper](https://sapper.svelte.dev/docs#rel_external) router.. Might not be the best way to handle that but I figured trying to parse the `href` and handle all the case (if it starts with `/`, if it contains the same `origin`, etc..) would be much more tedious, error prone and adding more size than just allowing the end user to mark a link as external.

We do have a use case for this on the solid website where we have a bunch of links that are in an array and rendered into the navbar. Some are external, some are internal.

We could also do a `<Dynamic component={item.external ? 'a' : 'Link'} ... />` but that felt a bit much compared to a couple of line in the router