### PR TITLE
Change `sideEffects` from string to boolean

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "files": [
     "dist"
   ],
-  "sideEffects": "false",
+  "sideEffects": false,
   "scripts": {
     "build": "tsc && rollup -c",
     "prepublishOnly": "npm run build"


### PR DESCRIPTION
According to the specification of `sideEffects` which is a Webpack thing apparently, the `sideEffects` value should be either a boolean or an array of string (that represent the files operating side effects).
Although I doubt this is a deal breaker, a warning is occasionally thrown in ESBuild (via vite):
```build
 > node_modules/.pnpm/solid-app-router@0.0.19_solid-js@0.23.11/node_modules/solid-app-router/package.json: warning: The value for "sideEffects" must be a boolean or an array
    23 │   "sideEffects": "false",
       ╵ 
```